### PR TITLE
Fix build error on Windows (#1637, @raulbocanegra)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,7 +90,9 @@ add_library(rdkafka ${RDKAFKA_BUILD_MODE} ${sources})
 
 # Support '#include <rdkafka.h>'
 target_include_directories(rdkafka PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>")
-
+if(RDKAFKA_BUILD_STATIC)
+  target_compile_definitions(rdkafka PUBLIC LIBRDKAFKA_STATICLIB)
+endif()
 # We need 'dummy' directory to support `#include "../config.h"` path
 set(dummy "${GENERATED_DIR}/dummy")
 file(MAKE_DIRECTORY "${dummy}")


### PR DESCRIPTION
Fix C2491: definition of dllimport static data member not allowed